### PR TITLE
Update Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ GOPATH  := $(ROOTDIR)/gopath
 export GOPATH
 
 blsd: git2go blsd.go
-	go build -ldflags -w
+	go build -ldflags -w -o $@
 
 $(GOPATH):
 	mkdir -p $@


### PR DESCRIPTION
and force output name to be `blsd`, so build works even if current
directory is not named `bsld`.

See https://golang.org/cmd/go/#hdr-Compile_packages_and_dependencies